### PR TITLE
Add binder

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,1 @@
+../environment.yml

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python setup.py install

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 [![CI](https://img.shields.io/github/workflow/status/MillionConcepts/lhorizon/CI?logo=github)](https://github.com/MillionConcepts/lhorizon/actions)
 [![codecov](https://codecov.io/gh/MillionConcepts/lhorizon/branch/main/graph/badge.svg)](https://codecov.io/gh/MillionConcepts/lhorizon)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/MillionConcepts/lhorizon/main?filepath=lhorizon%2Fexamples)
 
 ## introduction
 


### PR DESCRIPTION
Closes #12 

I've added the badge with the link to the binder environment.
https://mybinder.org/v2/gh/MillionConcepts/lhorizon/main?filepath=lhorizon%2Fexamples

However, the link above will only work after merging this PR (please check after merging).
Until then, you can test binder using this link:
https://mybinder.org/v2/gh/malmans2/lhorizon/add_binder?filepath=lhorizon%2Fexamples

A couple of suggestions:

1. I think you could move the `lhorizon/examples` to the root directory, it doesn't need to be under `/lhorizon`. If you do that, you'd have to update the binder link. The link generator is here: https://mybinder.org/
2. Right now only users familiar with binder would click on the binder badge. I'd mention that the notebooks can be executed interactively in a live environment and the link in the usage section

https://github.com/openjournals/joss-reviews/issues/3495